### PR TITLE
Add compose config for fdp-index v1 development

### DIFF
--- a/fdp/ephemeral/v1/dev/fdp-index/compose.override.yml
+++ b/fdp/ephemeral/v1/dev/fdp-index/compose.override.yml
@@ -1,0 +1,32 @@
+# note docker compose automatically loads compose.yml *and* compose.override.yml (if present)
+services:
+  mongo:
+    # when running the fdp-inex from source, it is not part of the docker network, so we need to expose mongo
+    ports:
+      - "127.0.0.1:27017:27017"
+  fdp-index-client:
+    depends_on: !reset []
+    # when running the fdp-index from source, the fdp-client needs network access to the docker host
+    environment:
+      FDP_HOST: host.docker.internal:8080
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  fdp:
+    # expose to docker host, so the fdp-index (running from source) can harvest the metadata
+    ports:
+      - "127.0.0.1:8081:8080"
+    environment:
+      # IMPORTANT: remove localhost from the deny-list in the fdp-index config,
+      # using the client's index settings, otherwise pings from this fdp are denied
+      # todo: implement a way to override the default denyList in the fdp
+      INSTANCE_CLIENTURL: http://localhost:8081
+      INSTANCE_INDEX: false
+      PING_ENABLED: true
+      PING_ENDPOINTS: http://host.docker.internal:8080
+      PING_INTERVAL: 5000
+      # the mongo db name must be different from that of the fdp-index
+      SPRING_DATA_MONGODB_URI: mongodb://mongo:27017/fdp-ping
+    # this fdp is used to ping the fdp-index that's running from source
+    # therefore, it needs network access to the docker host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/fdp/ephemeral/v1/dev/fdp-index/compose.yml
+++ b/fdp/ephemeral/v1/dev/fdp-index/compose.yml
@@ -1,0 +1,6 @@
+name: fdpev1devfdpindex
+include:
+  - ../../../../components/db/mongo.yml
+  - ../../../../components/v1/fdp-index-client.yml
+  # the fdp-index runs from source, but we add an additional fdp to generate pings
+  - ../../../../components/v1/fdp.yml

--- a/fdp/ephemeral/v1/dev/readme.md
+++ b/fdp/ephemeral/v1/dev/readme.md
@@ -1,0 +1,9 @@
+The compose configurations in the `dev` folder are to be used when you're running one of the components from source (on the Docker host machine).
+
+The name of the subfolder corresponds with the component that is running from source.
+
+For example, if you're running the `fdp` from source, you can use the compose file from `dev/fdp` to run `mongo` and `fdp-client` services.
+
+Similarly, if you're running an `fdp-index` from source, you can use `dev/fdp-index` to run `mongo`, `fdp-index-client`, and an additional `fdp` that sends frequent pings to your index.
+
+The `dev/fdp-ping` is a special case. You can use this when running `fdp` from source. It provides an additional `fdp-index` service, useful for testing your `fdp`'s ping functionality.


### PR DESCRIPTION
This configures the following services, assuming your fdp-index is running from source on the docker host:

- mongo
- fdp-index-client
- fdp (an additional fdp that pings your fdp-index and can be harvested)