### PR TITLE
Bump fdp image version from 1.20.0 to 1.20.1

### DIFF
--- a/fdp/components/v1/fdp-index.yml
+++ b/fdp/components/v1/fdp-index.yml
@@ -1,6 +1,6 @@
 services:
   fdp-index:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.0}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.1}"
     restart: no
     environment:
       FDP_MONGO_DB: 'fdp-index'

--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -1,6 +1,6 @@
 services:
   fdp:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.0}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.1}"
     restart: no
     environment:
       SERVER_PORT: 8080


### PR DESCRIPTION
This fixes the issue where fdp containers failed to start if the active profile was not explicitly specified.