### PR TITLE
Add config for end-to-end tests

### DIFF
--- a/fdp/ephemeral/v1/dev/e2e/compose.override.yml
+++ b/fdp/ephemeral/v1/dev/e2e/compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  mongo:
+    # expose port on docker host when running standalone
+    ports:
+      - "127.0.0.1:27017:27017"

--- a/fdp/ephemeral/v1/dev/e2e/compose.yml
+++ b/fdp/ephemeral/v1/dev/e2e/compose.yml
@@ -1,0 +1,5 @@
+name: fdpev1deve2e
+include:
+  - ../../../../components/db/mongo/compose.yml
+  - ../../../../components/v1/fdp.yml
+  - ../../../../components/v1/fdp-client.yml


### PR DESCRIPTION
Config that exposes mongodb on localhost, for end-to-end testing with https://github.com/FAIRDataTeam/FAIRDataPoint-E2E-Tests