### PR TITLE
Enable /actuator/metrics and /search/sparql endpoints

### DIFF
--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -6,6 +6,8 @@ services:
       SERVER_PORT: 8080
       INSTANCE_CLIENTURL: http://localhost
       INSTANCE_PERSISTENTURL: http://localhost
+      # enable /actuator/metrics endpoint (in addition to health and info endpoints)
+      MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health, info, metrics
     depends_on:
       mongo:
         condition: service_healthy

--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -8,6 +8,8 @@ services:
       INSTANCE_PERSISTENTURL: http://localhost
       # enable /actuator/metrics endpoint (in addition to health and info endpoints)
       MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE: health, info, metrics
+      # disable ping
+      PING_ENABLED: false
     depends_on:
       mongo:
         condition: service_healthy

--- a/fdp/persistent/v1/compose.override.yml
+++ b/fdp/persistent/v1/compose.override.yml
@@ -3,6 +3,9 @@ services:
   # configure fdp to use graphdb instead of the in-memory triple store
   fdp:
     environment:
+      # enable /search/sparql endpoint (proxy for external triple store sparql endpoint)
+      INSTANCE_SPARQLPROXYENABLED: true
+      # configure external triple store
       REPOSITORY_TYPE: 4
       REPOSITORY_GRAPHDB_URL: http://graphdb:7200
       REPOSITORY_GRAPHDB_REPOSITORY: fdp


### PR DESCRIPTION
- enabled `/actuator/metrics` for all v1 fdp (`components/v1/fdp.yml`)
- enabled `/search/sparql` for `persistent/v1` fdp
- disabled ping for all v1 fdp