### PR TITLE
Bump fdp from v1.20.4 to v1.22.0

### DIFF
--- a/fdp/components/v1/fdp-index.yml
+++ b/fdp/components/v1/fdp-index.yml
@@ -1,6 +1,6 @@
 services:
   fdp-index:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.4}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.21.0}"
     restart: no
     environment:
       FDP_MONGO_DB: 'fdp-index'

--- a/fdp/components/v1/fdp-index.yml
+++ b/fdp/components/v1/fdp-index.yml
@@ -1,6 +1,6 @@
 services:
   fdp-index:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.21.0}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.22.0}"
     restart: no
     environment:
       FDP_MONGO_DB: 'fdp-index'

--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -1,6 +1,6 @@
 services:
   fdp:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.20.4}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.21.0}"
     restart: no
     environment:
       SERVER_PORT: 8080

--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -1,6 +1,6 @@
 services:
   fdp:
-    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.21.0}"
+    image: "fairdata/fairdatapoint:${FDP_VERSION:-1.22.0}"
     restart: no
     environment:
       SERVER_PORT: 8080


### PR DESCRIPTION
v1.22.0 includes the `dcat:endpointDescription` statements for `/v3/api-docs` and `/swagger-ui.html`.