### PR TITLE
Increase fdp healthcheck interval from default 30s to 5m

### DIFF
--- a/fdp/components/v1/fdp-client.yml
+++ b/fdp/components/v1/fdp-client.yml
@@ -11,5 +11,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: wget --quiet --spider http://127.0.0.1 || exit 1
+      interval: 5m
       start_interval: 3s
       start_period: 30s

--- a/fdp/components/v1/fdp-index-client.yml
+++ b/fdp/components/v1/fdp-index-client.yml
@@ -11,3 +11,8 @@ services:
     depends_on:
       fdp-index:
         condition: service_healthy
+    healthcheck:
+      test: wget --quiet --spider http://127.0.0.1 || exit 1
+      interval: 5m
+      start_interval: 3s
+      start_period: 30s

--- a/fdp/components/v1/fdp-index.yml
+++ b/fdp/components/v1/fdp-index.yml
@@ -14,5 +14,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: "wget -q --spider http://localhost:${FDP_INDEX_PORT:-8082} || exit 1"
+      interval: 5m
       start_interval: 3s
       start_period: 30s

--- a/fdp/components/v1/fdp.yml
+++ b/fdp/components/v1/fdp.yml
@@ -15,5 +15,6 @@ services:
         condition: service_healthy
     healthcheck:
       test: wget --quiet --spider http://127.0.0.1:8080 || exit 1
+      interval: 5m
       start_interval: 3s
       start_period: 30s


### PR DESCRIPTION
This leads to fewer automated requests, which helps with debugging when running fdp from source, for development.